### PR TITLE
Show code coverage in github

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,21 +16,40 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
+    
     - name: Restore dependencies
       run: dotnet restore
+    
     - name: Build
       run: dotnet build --no-restore
+
     - name: Test
-      run: dotnet test AdoPipelineTest.UnitTests --no-build --verbosity normal --collect:"XPlat Code Coverage" --logger "trx;LogFileName=test-results.trx"
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      run: dotnet test AdoPipelineTest.UnitTests --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage --logger "trx;LogFileName=test-results.trx"
+
+    - name: Code Coverage Report
+      uses: irongut/CodeCoverageSummary@v1.3.0
       with:
-        files: ./AdoPipelineTest.UnitTests/coverage.cobertura.xml
-        flags: unittests
-        fail_ci_if_error: false
+        filename: coverage/**/coverage.cobertura.xml
+        badge: true
+        fail_below_min: true
+        format: markdown
+        hide_branch_rate: false
+        hide_complexity: true
+        indicators: true
+        output: both
+        thresholds: '60 80'
+
+    - name: Add Coverage PR Comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      if: github.event_name == 'pull_request'
+      with:
+        recreate: true
+        path: code-coverage-results.md
+        
     - name: Run sample tests
       run: dotnet test AdoPipelineTest.Samples --no-build --verbosity normal


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replace Codecov integration with CodeCoverageSummary action

- Generate markdown coverage report with badge and thresholds

- Add sticky PR comment to display coverage results

- Update test command to output coverage to results directory


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Execution"] -- "collect coverage" --> B["Coverage Results"]
  B -- "generate report" --> C["CodeCoverageSummary"]
  C -- "create markdown" --> D["PR Comment"]
  D -- "sticky comment" --> E["GitHub PR"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dotnet.yml</strong><dd><code>Replace Codecov with local coverage reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/dotnet.yml

<ul><li>Modified test step to output coverage results to <code>./coverage</code> directory<br> <li> Replaced Codecov action with CodeCoverageSummary action for local <br>coverage reporting<br> <li> Added CodeCoverageSummary step to generate markdown report with badge <br>and configurable thresholds<br> <li> Added sticky PR comment step to display coverage results on pull <br>requests</ul>


</details>


  </td>
  <td><a href="https://github.com/blakharaz/AdoPipelineTest/pull/3/files#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344">+25/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

