### PR TITLE
Show code coverage in github

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,7 +4,6 @@
 name: .NET
 
 permissions:
-  pull-requests: write
   contents: read
 
 on:
@@ -20,21 +19,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
-    
     - name: Restore dependencies
       run: dotnet restore
-    
     - name: Build
       run: dotnet build --no-restore
-
     - name: Test
       run: dotnet test AdoPipelineTest.UnitTests --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage --logger "trx;LogFileName=test-results.trx"
-
     - name: Code Coverage Report
       uses: irongut/CodeCoverageSummary@v1.3.0
       with:
@@ -47,13 +41,24 @@ jobs:
         indicators: true
         output: both
         thresholds: '60 80'
-
-    - name: Add Coverage PR Comment
-      uses: marocchino/sticky-pull-request-comment@v2
-      if: github.event_name == 'pull_request'
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v4
       with:
-        recreate: true
+        name: coverage-report
         path: code-coverage-results.md
-        
     - name: Run sample tests
       run: dotnet test AdoPipelineTest.Samples --no-build --verbosity normal
+
+  comment-pr:
+    if: github.event_name == 'pull_request'
+    needs: build
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: coverage-report
+    - uses: marocchino/sticky-pull-request-comment@v2.9.4
+      with:
+        path: code-coverage-results.md


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add code coverage reporting to GitHub pull requests

- Replace Codecov integration with CodeCoverageSummary action

- Generate markdown coverage report and post as PR comment

- Add workflow permissions for pull request write access


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Execution"] -- "generates coverage data" --> B["CodeCoverageSummary"]
  B -- "creates markdown report" --> C["Coverage Report File"]
  C -- "posted as comment" --> D["Pull Request"]
  E["Workflow Permissions"] -- "enables PR writes" --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dotnet.yml</strong><dd><code>Add GitHub PR code coverage reporting workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/dotnet.yml

<ul><li>Added workflow permissions for pull-requests write and contents read <br>access<br> <li> Modified test step to output coverage results to <code>./coverage</code> directory<br> <li> Replaced Codecov action with CodeCoverageSummary action for generating <br>coverage reports<br> <li> Added sticky pull request comment action to post coverage results as <br>PR comment<br> <li> Improved workflow formatting with consistent spacing between steps</ul>


</details>


  </td>
  <td><a href="https://github.com/blakharaz/AdoPipelineTest/pull/4/files#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344">+29/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

